### PR TITLE
38 webpage must be loaded for backend to initialize

### DIFF
--- a/webui/controls/__init__.py
+++ b/webui/controls/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'controls.apps.ControlsConfig'

--- a/webui/controls/apps.py
+++ b/webui/controls/apps.py
@@ -1,6 +1,13 @@
 from django.apps import AppConfig
+from controls.models import SystemConfig, StartupConfig
+from controls.api_comms import ApiComms
 
 
 class ControlsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'controls'
+
+    def ready(self):
+        api = ApiComms()
+        if SystemConfig.objects.exists() and StartupConfig.objects.exists():
+            api.configure()

--- a/webui/controls/apps.py
+++ b/webui/controls/apps.py
@@ -1,6 +1,4 @@
 from django.apps import AppConfig
-from controls.models import SystemConfig, StartupConfig
-from controls.api_comms import ApiComms
 
 
 class ControlsConfig(AppConfig):
@@ -8,6 +6,8 @@ class ControlsConfig(AppConfig):
     name = 'controls'
 
     def ready(self):
+        from controls.models import SystemConfig, StartupConfig
+        from controls.api_comms import ApiComms
         api = ApiComms()
         if SystemConfig.objects.exists() and StartupConfig.objects.exists():
             api.configure()

--- a/webui/controls/apps.py
+++ b/webui/controls/apps.py
@@ -8,6 +8,8 @@ class ControlsConfig(AppConfig):
     def ready(self):
         from controls.models import SystemConfig, StartupConfig
         from controls.api_comms import ApiComms
+        
         api = ApiComms()
+
         if SystemConfig.objects.exists() and StartupConfig.objects.exists():
             api.configure()

--- a/webui/controls/views.py
+++ b/webui/controls/views.py
@@ -13,10 +13,6 @@ from .api_comms import ApiComms
 
 api = ApiComms()
 
-# BUG: This only executes when a user loads a page and not when gunicon starts - https://github.com/Trogiken/chicken-door/projects/2#card-90775094
-# if SystemConfig.objects.exists() and StartupConfig.objects.exists():
-#     api.configure()
-
 
 def backend_init():
     """Init backend"""

--- a/webui/controls/views.py
+++ b/webui/controls/views.py
@@ -14,8 +14,8 @@ from .api_comms import ApiComms
 api = ApiComms()
 
 # BUG: This only executes when a user loads a page and not when gunicon starts - https://github.com/Trogiken/chicken-door/projects/2#card-90775094
-if SystemConfig.objects.exists() and StartupConfig.objects.exists():
-    api.configure()
+# if SystemConfig.objects.exists() and StartupConfig.objects.exists():
+#     api.configure()
 
 
 def backend_init():


### PR DESCRIPTION
Django uses the ready() method to talk to the API to configure the backend now.

This logic has been removed from views.py and placed in apps.py.
Used to initialize the application as soon as the system boots, instead of a user having to load a webpage, triggering the views.py file to then configure the API.